### PR TITLE
feat: add dual CJS and native ESM distribution outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ $ dodai dev
 
 ```tsx
 import * as React from 'react';
-import { HotReload } from '@potato4d/dodai/dist/hotreload';
+import { HotReload } from '@potato4d/dodai/hotreload';
 
 type LayoutProps = { head: JSX.Element | null; children?: React.ReactNode };
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "@potato4d/dodai",
   "version": "0.6.0",
   "description": "static website generator",
-  "main": "index.js",
+  "main": "./dist/cjs/index.js",
   "scripts": {
     "test": "npm run test",
-    "build": "tsc;chmod +x ./dist/index.js"
+    "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json && node -e \"require('fs').writeFileSync('dist/esm/package.json', JSON.stringify({ type: 'module' }, null, 2) + '\\n')\" && chmod +x ./dist/cjs/index.js"
   },
   "repository": {
     "type": "git",
@@ -17,9 +17,7 @@
     "build",
     "static-site-generator"
   ],
-  "bin": {
-    "dodai": "./dist/index.js"
-  },
+  "bin": "./dist/cjs/index.js",
   "author": "potato4d (Takuma HANATANI)",
   "license": "MIT",
   "bugs": {
@@ -48,5 +46,19 @@
     "rome": "^0.10.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
+  },
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js"
+    },
+    "./hotreload": {
+      "types": "./dist/types/hotreload.d.ts",
+      "require": "./dist/cjs/hotreload.js",
+      "import": "./dist/esm/hotreload.js"
+    }
   }
 }

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import * as chokidar from 'chokidar';
-import { build } from './build';
+import { build } from './build.js';
 import * as express from 'express';
 import { getPort, isSafePort } from 'get-port-please';
 const consola = require('consola');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 import { program } from 'commander';
-import { build } from './commands/build';
-import { dev } from './commands/dev';
-import { init } from './commands/init';
+import { build } from './commands/build.js';
+import { dev } from './commands/dev.js';
+import { init } from './commands/init.js';
 
 program.version('0.1.0', '-v, --version');
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "lib": ["ESNext", "DOM"],
+    "jsx": "react",
+    "moduleResolution": "Node",
+    "types": ["@types/node"],
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist/cjs",
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "esModuleInterop": false
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "es2020",
+    "outDir": "./dist/esm",
+    "declaration": false,
+    "esModuleInterop": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,26 +1,3 @@
 {
-  "compilerOptions": {
-    "declaration": true,
-    "target": "es2016",
-    "lib": [
-      "ESNext",
-      "DOM"
-    ],
-    "jsx": "react",
-    "module": "commonjs",
-    "moduleResolution": "Node",
-    "types": [
-      "@types/node"
-    ],
-    "outDir": "./dist",
-    "esModuleInterop": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true
-  },
-  "include": [
-    "src"
-  ],
+  "extends": "./tsconfig.cjs.json"
 }


### PR DESCRIPTION
### Motivation
- Provide both CommonJS and native ESM consumers for the package so it can be required and imported natively by Node.js projects. 
- Ensure emitted ESM files are resolvable under Node's ESM loader by using real ESM output and explicit `.js` specifiers where necessary. 

### Description
- Split TypeScript config into a shared base (`tsconfig.base.json`) and two targets: `tsconfig.cjs.json` (emits `./dist/cjs` + type declarations) and `tsconfig.esm.json` (emits `./dist/esm`).
- Update `tsconfig.json` to extend the CJS config for backward compatibility with previous workflow.
- Change build pipeline (`package.json` `build` script) to run `tsc -p tsconfig.cjs.json` and `tsc -p tsconfig.esm.json`, and write a nested `dist/esm/package.json` with `{ "type": "module" }` so ESM output is treated as native ESM.
- Update `package.json` entrypoints and metadata: set `main`, `module`, `types`, `bin`, and add an `exports` map (including `./hotreload`) to expose both `require` and `import` paths and shared type declarations.
- Adjust internal CLI source imports in `src/` to use explicit `.js` specifiers (`import ... from './commands/*.js'`) so the emitted ESM files work with Node's resolution.
- Update README example to import `HotReload` from the exported subpath (`@potato4d/dodai/hotreload`) instead of a `dist` path.

### Testing
- Ran `npm run build` which executes both CJS and ESM TypeScript compilations and completed successfully. (passed)
- Verified native ESM import with `node --input-type=module -e "import { HotReload } from './dist/esm/hotreload.js'; console.log(typeof HotReload);"` which printed `function`, confirming the ESM output is importable. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3751e187483219044d8a1af88ce93)